### PR TITLE
feat(proxy):DEV-159507 update flutter system proxy to 0.1.2

### DIFF
--- a/android/src/main/java/com/browserstack/fluttersystemproxy/flutter_system_proxy/FlutterSystemProxyPlugin.java
+++ b/android/src/main/java/com/browserstack/fluttersystemproxy/flutter_system_proxy/FlutterSystemProxyPlugin.java
@@ -3,6 +3,10 @@ package com.browserstack.fluttersystemproxy.flutter_system_proxy;
 import androidx.annotation.NonNull;
 import android.text.TextUtils;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,12 +35,26 @@ public class FlutterSystemProxyPlugin implements FlutterPlugin, MethodCallHandle
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
     if (call.method.equals("getDeviceProxy")) {
-      Map map = new HashMap<String, String>();
-      map.put("http.proxyHost", System.getProperty("http.proxyHost"));
-      map.put("http.proxyPort", System.getProperty("http.proxyPort"));
-      map.put("https.proxyHost", System.getProperty("https.proxyHost"));
-      map.put("https.proxyPort", System.getProperty("https.proxyPort"));
-      result.success(map);
+      HashMap<String, String> _map = new HashMap<String, String>() {
+        {
+          put("host", null);
+          put("port", null);
+        }
+      };
+      String url = call.argument("url");
+      ProxySelector selector = ProxySelector.getDefault();
+      try {
+        for (Proxy proxy : selector.select(new URI(url))) {
+          if (proxy.type() == Proxy.Type.HTTP) {
+            InetSocketAddress addr = (InetSocketAddress) proxy.address();
+            _map.put("host", addr.getHostName());
+            _map.put("port", Integer.toString(addr.getPort()));
+          }
+        }
+        result.success(_map);
+      } catch (Exception ex) {
+        result.error("URL Error",ex.getMessage(),null);
+      }
     } else {
       result.notImplemented();
     }

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+# platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_system_proxy/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_system_proxy: 96eb97e3857a1d1bc533a6f7387a1f0dcb63d782
 
-PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+PODFILE CHECKSUM: 7368163408c647b7eb699d0d788ba6718e18fb8d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -68,7 +68,6 @@
 				3D695DD80D4DCA36C1B83028 /* Pods-Runner.release.xcconfig */,
 				2B955829EF2302761365E6DB /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -156,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -200,10 +199,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -253,6 +254,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -263,7 +265,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -340,7 +342,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -356,10 +358,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 58NJ4M43R4;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.browserstack.fluttersystemproxy.flutterSystemProxyExample;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.browserstack.flutter-system-proxy-bstack";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -414,7 +420,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -463,7 +469,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -480,10 +486,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 58NJ4M43R4;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.browserstack.fluttersystemproxy.flutterSystemProxyExample;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.browserstack.flutter-system-proxy-bstack";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -499,10 +509,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 58NJ4M43R4;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.browserstack.fluttersystemproxy.flutterSystemProxyExample;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.browserstack.flutter-system-proxy-bstack";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -21,6 +23,8 @@
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: library_private_types_in_public_api
 
-import 'dart:developer';
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/adapter.dart';
@@ -45,10 +45,12 @@ class _MyHomePageState extends State<MyHomePage> {
   String _res = 'Response';
 
   void _incrementCounter() {
+    setState(() {
+        _counter++;
+      });
     fetchLocalHost().then((value) {
       setState(() {
-        _counter++;
-        _res = value;
+        _res = value.toString();
       });
     });
   }
@@ -87,11 +89,11 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 
 Future<String> fetchLocalHost() async {
-  try {
     final dio = Dio();
     const url = 'http://ip-api.com/json';
-    final proxy = await FlutterSystemProxy.findProxyFromEnvironment(url);
-    (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate = (HttpClient client) {
+    final proxy = await FlutterSystemProxy().findProxyFromEnvironment(url);
+    (dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+        (HttpClient client) {
       client.findProxy = (uri) {
         return proxy;
       };
@@ -99,8 +101,4 @@ Future<String> fetchLocalHost() async {
     };
     final response = await dio.get(url);
     return response.toString();
-  } catch (e) {
-    log(e.toString());
-    return 'Error';
-  }
 }

--- a/ios/Classes/SwiftFlutterSystemProxyPlugin.swift
+++ b/ios/Classes/SwiftFlutterSystemProxyPlugin.swift
@@ -1,7 +1,10 @@
 import Flutter
 import UIKit
 import JavaScriptCore
+
 public class SwiftFlutterSystemProxyPlugin: NSObject, FlutterPlugin {
+  static var proxyCache : [String: [String: Any]] = [:]
+  
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_system_proxy", binaryMessenger: registrar.messenger())
     let instance = SwiftFlutterSystemProxyPlugin()
@@ -11,28 +14,109 @@ public class SwiftFlutterSystemProxyPlugin: NSObject, FlutterPlugin {
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "getDeviceProxy":
-      let systemProxySettings = CFNetworkCopySystemProxySettings()?.takeUnretainedValue() ?? [:] as CFDictionary
-      result(systemProxySettings as NSDictionary)
-      break
-    case "executePAC":
-      let systemProxySettings = CFNetworkCopySystemProxySettings()?.takeUnretainedValue() ?? [:] as CFDictionary
-      let proxyDict = systemProxySettings as NSDictionary
-      if(proxyDict.value(forKey:"ProxyAutoConfigEnable")as! Bool){
+        do {
         let args = call.arguments as! NSDictionary
         let url = args.value(forKey:"url") as! String
-        let host = args.value(forKey:"host") as! String
-        let js = args.value(forKey:"js") as! String
-        let jsEngine:JSContext = JSContext()
-        jsEngine.evaluateScript(js)
-        let fn = "FindProxyForURL(\"" + url + "\",\""+host+"\")"
-        let proxy = jsEngine.evaluateScript(fn)
-        result(proxy?.toString())
-      }else{
-        result("DIRECT")
-      }
-      break
+        var dict:[String:Any] = [:]
+        if(SwiftFlutterSystemProxyPlugin.proxyCache[url] != nil){
+            let res = SwiftFlutterSystemProxyPlugin.proxyCache[url]
+            if(res != nil){
+                dict = res as! [String:Any]
+            }
+        } 
+        else 
+        {
+            let res = try SwiftFlutterSystemProxyPlugin.resolve(url: url)
+            if(res != nil){
+                dict = res as! [String:Any]
+            }
+        }
+        result(dict)
+        } catch let error {
+            print("Unexpected Proxy Error: \(error).")
+            result(error)
+        }
+        break
     default:
       result(FlutterMethodNotImplemented)
     }
   }
+
+  static func resolve(url:String)->[String:Any]?{
+        if(SwiftFlutterSystemProxyPlugin.proxyCache[url] != nil){
+            return SwiftFlutterSystemProxyPlugin.proxyCache[url]
+        }
+        let proxConfigDict = CFNetworkCopySystemProxySettings()?.takeUnretainedValue() as NSDictionary?
+        if(proxConfigDict != nil){
+            if(proxConfigDict!["ProxyAutoConfigEnable"] as? Int == 1){
+                let pacUrl = proxConfigDict!["ProxyAutoConfigURLString"] as? String
+                let pacContent = proxConfigDict!["ProxyAutoConfigJavaScript"] as? String
+                if(pacContent != nil){
+                    self.handlePacContent(pacContent: pacContent! as String, url: url)
+                }else if(pacUrl != nil){
+                    self.handlePacUrl(pacUrl: pacUrl!,url: url)
+                }
+            } else if (proxConfigDict!["HTTPEnable"] as? Int == 1){
+                var dict: [String: Any] = [:]
+                dict["host"] = proxConfigDict!["HTTPProxy"] as? String
+                dict["port"] = proxConfigDict!["HTTPPort"] as? Int
+                SwiftFlutterSystemProxyPlugin.proxyCache[url] = dict
+                
+            } else if ( proxConfigDict!["HTTPSEnable"] as? Int == 1){
+                var dict: [String: Any] = [:]
+                dict["host"] = proxConfigDict!["HTTPSProxy"] as? String
+                dict["port"] = proxConfigDict!["HTTPSPort"] as? Int
+                SwiftFlutterSystemProxyPlugin.proxyCache[url] = dict
+            }
+        }
+        return SwiftFlutterSystemProxyPlugin.proxyCache[url]
+    }
+    
+    static func handlePacContent(pacContent: String,url: String){
+        let proxies = CFNetworkCopyProxiesForAutoConfigurationScript(pacContent as CFString, CFURLCreateWithString(kCFAllocatorDefault, url as CFString, nil), nil)!.takeUnretainedValue() as? [[CFString: Any]] ?? [];
+        if(proxies.count > 0){
+            let proxy = proxies.first{$0[kCFProxyTypeKey] as! CFString == kCFProxyTypeHTTP || $0[kCFProxyTypeKey] as! CFString == kCFProxyTypeHTTPS}
+            if(proxy != nil){
+                let host = proxy?[kCFProxyHostNameKey] ?? nil
+                let port = proxy?[kCFProxyPortNumberKey] ?? nil
+                var dict:[String: Any] = [:]
+                dict["host"] = host
+                dict["port"] = port
+                SwiftFlutterSystemProxyPlugin.proxyCache[url] = dict
+            }
+        }
+    }
+
+    static func handlePacUrl(pacUrl: String, url: String){
+        var _pacUrl = CFURLCreateWithString(kCFAllocatorDefault,  pacUrl as CFString?,nil)
+        var targetUrl = CFURLCreateWithString(kCFAllocatorDefault, url as CFString?, nil)
+        var info = url;
+        if(pacUrl != nil && targetUrl != nil){
+            var context:CFStreamClientContext = CFStreamClientContext.init(version: 0, info: &info, retain: nil, release: nil, copyDescription: nil)
+            let runLoopSource = CFNetworkExecuteProxyAutoConfigurationURL(_pacUrl!,targetUrl!,  { client, proxies, error in
+                let _proxies = proxies as? [[CFString: Any]] ?? [];
+                if(_proxies != nil){
+                    if(_proxies.count > 0){
+                    let proxy = _proxies.first{$0[kCFProxyTypeKey] as! CFString == kCFProxyTypeHTTP || $0[kCFProxyTypeKey] as! CFString == kCFProxyTypeHTTPS}
+                    if(proxy != nil){
+                        let host = proxy?[kCFProxyHostNameKey] ?? nil
+                        let port = proxy?[kCFProxyPortNumberKey] ?? nil
+                        var dict:[String: Any] = [:]
+                        dict["host"] = host
+                        dict["port"] = port
+                        let url = client.assumingMemoryBound(to: String.self).pointee
+                        SwiftFlutterSystemProxyPlugin.proxyCache[url] = dict
+                    }     
+                }
+            }
+                CFRunLoopStop(CFRunLoopGetCurrent());
+            }, &context).takeUnretainedValue()
+            let runLoop = CFRunLoopGetCurrent();
+            CFRunLoopAddSource(runLoop, runLoopSource, CFRunLoopMode.defaultMode);
+            CFRunLoopRun();
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.defaultMode);
+        }
+    }
+    
 }
+

--- a/lib/flutter_system_proxy.dart
+++ b/lib/flutter_system_proxy.dart
@@ -1,98 +1,39 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:developer';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
 
-// ignore: avoid_classes_with_only_static_members
 class FlutterSystemProxy {
   static const MethodChannel _channel = MethodChannel('flutter_system_proxy');
 
-  static Future<Map<String, String>?> _getSystemProxy(String url) async {
-    final bool isHttps = Uri.parse(url).scheme == 'https';
-    final dynamic proxySettings = await _channel.invokeMethod('getDeviceProxy');
-    if (Platform.isAndroid) {
-      if (isHttps) {
-        if (!isNullOrEmpty(proxySettings['https.proxyHost']) && isPort(proxySettings['https.proxyPort'])) {
-          return {
-            'enabled': 'true',
-            'host': proxySettings['https.proxyHost'],
-            'port': proxySettings['https.proxyPort']
-          };
-        }
-      } else {
-        if (!isNullOrEmpty(proxySettings['http.proxyHost']) && isPort(proxySettings['http.proxyPort'])) {
-          return {'enabled': 'true', 'host': proxySettings['http.proxyHost'], 'port': proxySettings['http.proxyPort']};
-        }
-      }
-      return null;
-    } else if (Platform.isIOS) {
-      if (proxySettings['ProxyAutoConfigEnable'] == 1) {
-        return {'pacEnabled': 'true', 'pacUrl': proxySettings['ProxyAutoConfigURLString']};
-      } else {
-        if (isHttps) {
-          if (proxySettings['HTTPSEnable'] == 1) {
-            return {
-              'enabled': 'true',
-              'host': proxySettings['HTTPSProxy'].toString(),
-              'port': proxySettings['HTTPSPort'].toString()
-            };
-          }
-        } else {
-          if (proxySettings['HTTPEnable'] == 1) {
-            return {
-              'enabled': 'true',
-              'host': proxySettings['HTTPProxy'].toString(),
-              'port': proxySettings['HTTPPort'].toString()
-            };
-          }
-        }
-        return null;
-      }
-    }
-    return null;
+  /// returns host and port from environment
+  Future<dynamic> getEnvironmentProxy(String url) async {
+    return _channel.invokeMethod('getDeviceProxy', <String, dynamic>{'url': url});
   }
 
-  static Future<String> findProxyFromEnvironment(String url) async {
-    final parsedProxy = await _getSystemProxy(url);
-    log(parsedProxy.toString());
-    final host = Uri.parse(url).host;
-    if (parsedProxy != null && parsedProxy['enabled'] == 'true') {
-      return 'PROXY ${parsedProxy['host'] as String}:${parsedProxy['port'] as String}';
-    } else if (parsedProxy != null && parsedProxy['pacEnabled'] == 'true' && parsedProxy['pacUrl'] != null) {
-      final String pacLocation = parsedProxy['pacUrl'] as String;
-      final String jsContents = await contents(pacLocation);
-      final String proxy = await _channel.invokeMethod('executePAC', {'url': url, 'host': host, 'js': jsContents});
-      return proxy;
+  /// returns Proxy String
+  Future<String> findProxyFromEnvironment(String url) async {
+    final dynamic proxySettings = await getEnvironmentProxy(url);
+    if (!isNullOrEmpty(proxySettings['host']) && isPort(proxySettings['port'])) {
+      return 'PROXY ${proxySettings['host']}:${proxySettings['port']}';
     } else {
       return HttpClient.findProxyFromEnvironment(Uri.parse(url));
     }
   }
-}
 
-bool isNullOrEmpty(String? str) {
-  return str == null || str == '';
-}
-
-bool isPort(String? port) {
-  if (port == null) {
-    return false;
+  bool isNullOrEmpty(String? str) {
+    return str == null || str == '';
   }
-  final number = num.tryParse(port);
-  if (number != null && number > 0) {
-    return true;
-  } else {
-    return false;
-  }
-}
 
-Future<String> contents(String url) async {
-  final HttpClient client = HttpClient();
-  final completor = Completer<String>();
-  client.findProxy = null;
-  final request = await client.getUrl(Uri.parse(url));
-  final response = await request.close();
-  response.transform(utf8.decoder).listen(completor.complete);
-  return completor.future;
+  bool isPort(dynamic port) {
+    if (port == null) {
+      return false;
+    }
+    final number = num.tryParse(port.toString());
+    if (number != null && number > 0 && number <= 65536) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/pac/test.pac
+++ b/pac/test.pac
@@ -1,0 +1,8 @@
+function FindProxyForURL(url, host)
+{
+    if(host.includes("ip-api")){
+     return "PROXY 127.0.0.1:8000"
+    }else{
+        return "DIRECT"
+    }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_system_proxy
 description: A Flutter Plugin to detect System proxy. When using HTTP client that are not proxy aware this plugin can help with finding the proxy from system settings which then can be used with HTTP Client to make a successful request.
-homepage: https://github.com/Rushabhshroff/flutter_system_proxy.git
+homepage: https://github.com/BrowserStackCE/flutter_system_proxy.git
 publish_to: https://dart.cloudsmith.io/alkami/flutter/
-version: 3.15.0 #Original version when cloned was 0.0.2
+version:  3.15.0 #Original version when cloned was 0.1.2
 
 environment:
   sdk: ">=2.18.0 <3.0.0"


### PR DESCRIPTION
## Acceptance criteria
- [x] Update the BrowserStack dependency in the fork
- [] update the developer tool code for selecting the specific URL of environment that requires by new tool of Browserstack.

## Notes
New flutter system proxy require a valid url that pass to method call instead of empty url. After trying all urls of env (production, staging, and QAs), returned proxy IP address and port are the same, so I used the url of Demo env to pass to method call. From that, there is no change in flow in Developer tool that let user to select a specific env. Therefore, second bullet is not needed. 
